### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "baseof"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-05-18
+lastmod: 2026-05-20
 ---
 
 ### AI/ML
@@ -228,3 +228,8 @@ lastmod: 2026-05-18
 
 1. [Community Writer Programs](https://github.com/malgamves/CommunityWriterPrograms)
 
+---
+
+### generic
+
+1. [Test Link](https://example.com/test) - Testing the save-link function


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-05-18T08:32:48Z
- Auto-generated by GitHub Actions