### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "baseof"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-05-18
+lastmod: 2026-05-25
 ---
 
 ### AI/ML
@@ -227,4 +227,3 @@ lastmod: 2026-05-18
 ### Writing
 
 1. [Community Writer Programs](https://github.com/malgamves/CommunityWriterPrograms)
-


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-05-22T09:10:51Z
- Auto-generated by GitHub Actions