### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "baseof"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-05-25
+lastmod: 2026-05-26
 ---
 
 ### AI/ML


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-05-25T07:14:49Z
- Auto-generated by GitHub Actions