### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "baseof"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-05-25
+lastmod: 2026-05-27
 ---
 
 ### AI/ML


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-05-26T15:30:35Z
- Auto-generated by GitHub Actions