### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "links"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-06-03
+lastmod: 2026-06-05
 ---
 
 ### AI/ML
@@ -53,6 +53,7 @@ lastmod: 2026-06-03
 
 1. [CMU - Intro to Database Systems](https://15445.courses.cs.cmu.edu/)
 2. [Postgres Is Enough](https://gist.github.com/cpursley/c8fb81fe8a7e5df038158bdfe0f06dbb)
+3. [Redis is fast - I'll cache in Postgres](https://dizzy.zone/2025/09/24/Redis-is-fast-Ill-cache-in-Postgres/)
 
 ---
 


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-06-03T09:12:41Z
- Auto-generated by GitHub Actions