### PR TITLE
chore: Sync Links from LinkSync

### DIFF
--- a/content/links.md
+++ b/content/links.md
@@ -5,7 +5,7 @@ layout: "links"
 comments: false
 tocopen: false
 showPostNavLinks: false
-lastmod: 2026-06-29
+lastmod: 2026-07-02
 ---
 
 ### AI/ML


### PR DESCRIPTION
This PR updates the links page with new links saved via the LinkSync Chrome extension.

- Synced from Supabase database at 2026-06-29T08:02:07Z
- Auto-generated by GitHub Actions